### PR TITLE
Fix jquery-rails version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '3.2.3'
-gem 'jquery-rails', '2.0.0'
+gem 'jquery-rails', '~> 2.0.0'
 gem 'bootstrap-sass', '2.0.0'
 gem 'bcrypt-ruby', '3.0.1'
 gem 'faker', '1.0.1'


### PR DESCRIPTION
When I run bundle install with this gem I got error: "Could not find gem 'jquery-rails (= 2.0.0) ruby' in the gems available on this machine"
There is no v2.0.0 jquery-rails gem available: http://stackoverflow.com/questions/14178744/could-not-find-gem-jquery-rails-2-0-0-ruby-in-the-gems-available-on-this-m
